### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # tweakpane-table
 
+[![Run in Smithery](https://smithery.ai/badge/skills/amir-arad)](https://smithery.ai/skills?ns=amir-arad&utm_source=github&utm_medium=badge)
+
+
 ![tweakpane-table-demo](https://user-images.githubusercontent.com/6019373/218509852-643003ac-7092-4840-ab03-f919178588a2.png)
 
 Table plugin for [Tweakpane](https://github.com/cocopon/tweakpane/).


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/amir-arad)](https://smithery.ai/skills?ns=amir-arad&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.